### PR TITLE
fix(snapshot): avoid creating unused screenshot folders

### DIFF
--- a/playbook_snapshot/lib/src/snapshot.dart
+++ b/playbook_snapshot/lib/src/snapshot.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:playbook/playbook.dart';
@@ -16,11 +15,8 @@ class Snapshot extends TestTool {
       await FontBuilder.loadFonts();
     });
 
-    await Directory(directoryPath).create();
-
     for (final device in devices) {
       final ensuredDirectoryPath = '$directoryPath/${device.name}';
-      await Directory(ensuredDirectoryPath).create();
 
       for (final story in playbook.stories) {
         for (final scenario in story.scenarios) {


### PR DESCRIPTION
It seem folder will be automatically created under `lib/test`(the same folder of the test file) folder.
The code deleted in this PR are creating folder under the `lib` folder.