### PR TITLE
fix: use dependency_overrides for playbook

### DIFF
--- a/playbook_snapshot/pubspec.yaml
+++ b/playbook_snapshot/pubspec.yaml
@@ -14,9 +14,12 @@ dependencies:
 
   # Dependency
   playbook:
-    path: ../playbook
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   effective_dart: ^1.3.0
+
+dependency_overrides:
+  playbook:
+    path: ../playbook

--- a/playbook_ui/pubspec.yaml
+++ b/playbook_ui/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
 
   # Dependency
   playbook:
-    path: ../playbook
 
 dev_dependencies:
   flutter_test:
@@ -23,3 +22,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  playbook:
+    path: ../playbook


### PR DESCRIPTION
FIX:
```
[catalog_app]: ERR : Error on line 17, column 11: Invalid description in the "playbook_snapshot" pubspec on the "playbook" dependency: "../playbook" is a relative path, but this isn't a local pubspec.
[catalog_app]: 
[catalog_app]:     |    ╷
[catalog_app]: 
[catalog_app]:     | 17 │     path: ../playbook
```

Seems a bug of pubspec.
Use dependency_overrides so we can depend all three `playbook` packages via git:

```yaml
dependencies:
  flutter:
    sdk: flutter
  playbook:
  playbook_ui:

dev_dependencies:
  flutter_test:
    sdk: flutter
  playbook_snapshot:

dependency_overrides:
  playbook:
    git:
      url: git@github.com:ca-irvine/playbook-flutter.git
      path: playbook/
  playbook_ui:
    git:
      url: git@github.com:ca-irvine/playbook-flutter.git
      path: playbook_ui/
  playbook_snapshot:
    git:
      url: git@github.com:ca-irvine/playbook-flutter.git
      path: playbook_snapshot/
```