### PR TITLE
fix: disable hero mode instead of nested navigator hack

### DIFF
--- a/examples/simple_example/simple_catalog_app/lib/hero/multiple_hero.dart
+++ b/examples/simple_example/simple_catalog_app/lib/hero/multiple_hero.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:playbook/playbook.dart';
+
+Story multipleHeroStoryForTest() {
+  return Story('MultipleHeroStoryForTest', scenarios: [
+    Scenario(
+      'Hero1',
+      child: _HeroTest(),
+    ),
+    Scenario(
+      'Hero2',
+      child: _HeroTest(),
+    ),
+    Scenario(
+      'Hero3',
+      child: _HeroTest(),
+    ),
+  ]);
+}
+
+class _HeroTest extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Hero(
+      tag: 'hero_tag',
+      child: const SizedBox(),
+    );
+  }
+}

--- a/examples/simple_example/simple_catalog_app/lib/main.dart
+++ b/examples/simple_example/simple_catalog_app/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:playbook/playbook.dart';
 import 'package:playbook_ui/playbook_ui.dart';
 import 'package:simple_catalog_app/bar/bar.dart';
 import 'package:simple_catalog_app/foo/foo_widget.dart';
+import 'package:simple_catalog_app/hero/multiple_hero.dart';
 import 'package:simple_catalog_app/image/asset_image.dart';
 
 void main() {
@@ -22,6 +23,7 @@ class MyApp extends StatelessWidget {
             barStory(),
             fooWidgetStory(),
             assetImageStory(),
+            multipleHeroStoryForTest(),
           ],
         ),
       ),

--- a/playbook_ui/lib/src/playbook_gallery.dart
+++ b/playbook_ui/lib/src/playbook_gallery.dart
@@ -43,83 +43,80 @@ class _PlaybookGalleryState extends State<PlaybookGallery> {
   @override
   Widget build(BuildContext context) {
     final theme = widget.theme ?? Theme.of(context);
-    return _PageRoute(
+    return ThemeProvider(
       theme: theme,
-      child: ThemeProvider(
-        theme: theme,
-        child: Scaffold(
-          body: CustomScrollView(
-            slivers: [
-              SliverAppBar(
-                pinned: true,
-                expandedHeight: 88,
-                flexibleSpace: FlexibleSpaceBar(
-                  title: Text(
-                    widget.title,
-                    style: Theme.of(context).textTheme.bodyText1,
-                  ),
+      child: Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            SliverAppBar(
+              pinned: true,
+              expandedHeight: 88,
+              flexibleSpace: FlexibleSpaceBar(
+                title: Text(
+                  widget.title,
+                  style: Theme.of(context).textTheme.bodyText1,
                 ),
               ),
-              SliverPersistentHeader(
-                delegate: SearchHeaderDelegate(
-                  controller: _textEditingController,
-                ),
+            ),
+            SliverPersistentHeader(
+              delegate: SearchHeaderDelegate(
+                controller: _textEditingController,
               ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final story = _stories.elementAt(index);
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const SizedBox(height: 16),
-                        Row(
-                          children: [
-                            const SizedBox(width: 20),
-                            const Icon(Icons.folder_outlined, color: Colors.blue),
-                            const SizedBox(width: 8),
-                            Flexible(
-                              child: Text(
-                                story.title,
-                                style: Theme.of(context).textTheme.headline6?.copyWith(
-                                      color: Theme.of(context).textTheme.headline3?.color,
-                                    ),
-                              ),
+            ),
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final story = _stories.elementAt(index);
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 16),
+                      Row(
+                        children: [
+                          const SizedBox(width: 20),
+                          const Icon(Icons.folder_outlined, color: Colors.blue),
+                          const SizedBox(width: 8),
+                          Flexible(
+                            child: Text(
+                              story.title,
+                              style: Theme.of(context).textTheme.headline6?.copyWith(
+                                    color: Theme.of(context).textTheme.headline3?.color,
+                                  ),
                             ),
-                            const SizedBox(width: 16),
-                          ],
-                        ),
-                        const SizedBox(height: 16),
-                        SingleChildScrollView(
-                          key: PageStorageKey(index),
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          scrollDirection: Axis.horizontal,
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          clipBehavior: Clip.none,
-                          child: Wrap(
-                            spacing: 16,
-                            children: story.scenarios
-                                .map((e) => ScenarioContainer(key: ValueKey(e), scenario: e))
-                                .toList()
-                              ..sort(
-                                (s1, s2) => s1.scenario.title.compareTo(s2.scenario.title),
-                              ),
                           ),
+                          const SizedBox(width: 16),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      SingleChildScrollView(
+                        key: PageStorageKey(index),
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        scrollDirection: Axis.horizontal,
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        clipBehavior: Clip.none,
+                        child: Wrap(
+                          spacing: 16,
+                          children: story.scenarios
+                              .map((e) => ScenarioContainer(key: ValueKey(e), scenario: e))
+                              .toList()
+                            ..sort(
+                              (s1, s2) => s1.scenario.title.compareTo(s2.scenario.title),
+                            ),
                         ),
-                        const SizedBox(height: 8),
-                      ],
-                    );
-                  },
-                  childCount: _stories.length,
-                ),
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                  );
+                },
+                childCount: _stories.length,
               ),
-              SliverPadding(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).padding.bottom,
-                ),
+            ),
+            SliverPadding(
+              padding: EdgeInsets.only(
+                bottom: MediaQuery.of(context).padding.bottom,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
@@ -149,27 +146,5 @@ class _PlaybookGalleryState extends State<PlaybookGallery> {
           .toList();
     }
     _stories.sort((s1, s2) => s1.title.compareTo(s2.title));
-  }
-}
-
-class _PageRoute extends StatelessWidget {
-  const _PageRoute({
-    Key? key,
-    required this.theme,
-    required this.child,
-  }) : super(key: key);
-
-  final ThemeData theme;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Navigator(
-      onGenerateRoute: (_) {
-        return theme.platform == TargetPlatform.iOS
-            ? CupertinoPageRoute(builder: (_) => child)
-            : MaterialPageRoute(builder: (_) => child);
-      },
-    );
   }
 }

--- a/playbook_ui/lib/src/scenario_container.dart
+++ b/playbook_ui/lib/src/scenario_container.dart
@@ -44,7 +44,11 @@ class ScenarioContainer extends StatelessWidget {
                               alignment: scenario.alignment,
                               child: Theme(
                                 data: ThemeProvider.of(context).theme,
-                                child: scenario.child,
+                                // Because we may have multiple heroes that share the same tag
+                                child: HeroMode(
+                                  enabled: false,
+                                  child: scenario.child,
+                                ),
                               ),
                             ),
                           ),


### PR DESCRIPTION
With the nested navigator hack we have two problems:
- Search cannot update state properly
- Android back key will pop up the whole app

For fixing multiple hero exceptions, we can simply disable the hero via `HeroMode` in the catalog.

Video of search bug:

https://user-images.githubusercontent.com/13031690/144692598-ed719e04-88c9-4d3f-9612-614e053bcb85.mp4


