### PR TITLE
fix:  playbook builder's story assets glob path

### DIFF
--- a/playbook_generator/lib/src/playbook_builder.dart
+++ b/playbook_generator/lib/src/playbook_builder.dart
@@ -23,7 +23,7 @@ class PlaybookBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final storyAssets = buildStep.findAssets(Glob('lib/**/*.story.dart'));
+    final storyAssets = buildStep.findAssets(Glob('lib/**.story.dart'));
     final storyFunctions = <Method>[];
 
     await for (final input in storyAssets) {


### PR DESCRIPTION
I fixed as per title because I want to generate scenarios for the `*.story.dart` file in root path, too.