### PR TITLE
feat: expose search field's TextEditingController

### DIFF
--- a/playbook_ui/lib/src/playbook_gallery.dart
+++ b/playbook_ui/lib/src/playbook_gallery.dart
@@ -8,12 +8,14 @@ class PlaybookGallery extends StatefulWidget {
   const PlaybookGallery({
     Key? key,
     this.title = 'Playbook',
+    this.textEditingController,
     this.onCustomActionPressed,
     this.otherCustomActions = const [],
     required this.playbook,
   }) : super(key: key);
 
   final String title;
+  final TextEditingController? textEditingController;
   final VoidCallback? onCustomActionPressed;
   final List<Widget> otherCustomActions;
   final Playbook playbook;
@@ -23,13 +25,14 @@ class PlaybookGallery extends StatefulWidget {
 }
 
 class _PlaybookGalleryState extends State<PlaybookGallery> {
-  final _textEditingController = TextEditingController();
+  late final TextEditingController _textEditingController;
   final _scrollController = ScrollController();
   List<Story> _stories = [];
 
   @override
   void initState() {
     super.initState();
+    _textEditingController = widget.textEditingController ?? TextEditingController();
     _updateStoriesFromSearch();
     _textEditingController.addListener(() {
       setState(_updateStoriesFromSearch);


### PR DESCRIPTION
This PR exposes the search field's TextEditingController for extensibility.
I'm planning to use this for setting or getting the current search query.