### PR TITLE
PlaybookGallery now respects AppBarTheme.titleTextStyle

### DIFF
--- a/playbook_ui/lib/src/playbook_gallery.dart
+++ b/playbook_ui/lib/src/playbook_gallery.dart
@@ -68,7 +68,10 @@ class _PlaybookGalleryState extends State<PlaybookGallery> {
               pinned: true,
               expandedHeight: 128,
               flexibleSpace: FlexibleSpaceBar(
-                title: Text(widget.title),
+                title: Text(
+                  widget.title,
+                  style: AppBarTheme.of(context).titleTextStyle,
+                ),
                 centerTitle: true,
                 background: GestureDetector(
                   onDoubleTap: () => _scrollController.animateTo(


### PR DESCRIPTION
## Description
`PlaybookGallery` widget respects `AppBarTheme.backgroundColor` but not `AppBarTheme.titleTextStyle`.
This causes an issue when the `backgroundColor` is set to `Colors.white`, the title text color may be also white, making it unreadable.
This PR fixes the issue.

## Showcase

With the following `AppBarTheme`.

```dart
AppBarTheme(
  backgroundColor: Colors.white,
  titleTextStyle: TextStyle(color: Colors.black),
  iconTheme: IconThemeData(color: Colors.grey),
)
```

|Default|With `white` background|Fixed by this PR|
|-|-|-|
|<img src=https://user-images.githubusercontent.com/1316988/195783265-4cef755a-83f1-44d3-9bec-3c93f1faedbd.png  width=240>|<img src=https://user-images.githubusercontent.com/1316988/195783301-a6c18cef-cbeb-48d7-8462-288e83fde73e.png  width=240>|<img src=https://user-images.githubusercontent.com/1316988/195783321-9dee922f-b94a-4115-bff1-4100feaed887.png  width=240>|