### PR TITLE
fix: font load timing

### DIFF
--- a/playbook_snapshot/lib/src/font_builder.dart
+++ b/playbook_snapshot/lib/src/font_builder.dart
@@ -30,8 +30,9 @@ class FontBuilder {
         final assetFile = File('${configurations['asset']}');
         final fontData = await assetFile.readAsBytes();
         loader.addFont(Future.value(ByteData.view(fontData.buffer)));
-        await loader.load();
       }
+
+      await loader.load();
     }
   }
 


### PR DESCRIPTION
When there are two or more font assets, the second one fails to load when the first one loads, so the second one is loaded when all additions are complete.