### PR TITLE
build: support analyzer v6

### DIFF
--- a/playbook_generator/pubspec.yaml
+++ b/playbook_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.6.0 <6.0.0'
+  analyzer: '>=4.6.0 <7.0.0'
   build: ^2.0.0
   source_gen: ^1.0.0
   path: ^1.8.0


### PR DESCRIPTION
### Overview
Update pubspec on `playbook_generator` and support analyzer v6.
Newest `riverpod_lint` supports only above v6. [^1]

[^1]: https://github.com/rrousselGit/riverpod/blob/2566f9b8e7f12de87abeefbc0085b0942a064350/packages/riverpod_lint/pubspec.yaml#L14