### PR TITLE
feat: Support Scrollables have no ScrollController

### DIFF
--- a/examples/simple_example/simple_catalog_app/lib/scrollable/scrollable.dart
+++ b/examples/simple_example/simple_catalog_app/lib/scrollable/scrollable.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:playbook/playbook.dart';
+
+Widget scrollable({required bool primary}) => Row(
+      children: [
+        Flexible(
+          child: ListView.builder(
+            primary: primary,
+            itemBuilder: (context, index) => Material(
+              type: MaterialType.transparency,
+              child: ListTile(
+                title: Text('Item $index'),
+              ),
+            ),
+            itemCount: 40,
+          ),
+        ),
+        Flexible(
+          child: ListView.builder(
+            primary: primary,
+            itemBuilder: (context, index) => Material(
+              type: MaterialType.transparency,
+              child: ListTile(
+                title: Text('Item $index'),
+              ),
+            ),
+            itemCount: 10,
+          ),
+        ),
+      ],
+    );
+
+Story scrollableStory() {
+  return Story('Scrollable', scenarios: [
+    Scenario(
+      'Primary Scrollable',
+      child: scrollable(primary: true),
+    ),
+    Scenario(
+      'Not Primary Scrollable',
+      child: scrollable(primary: false),
+    )
+  ]);
+}

--- a/examples/simple_example/simple_catalog_app/test/snapshot_test.dart
+++ b/examples/simple_example/simple_catalog_app/test/snapshot_test.dart
@@ -5,6 +5,7 @@ import 'package:playbook_snapshot/playbook_snapshot.dart';
 import 'package:simple_catalog_app/bar/bar.dart';
 import 'package:simple_catalog_app/foo/foo_widget.dart';
 import 'package:simple_catalog_app/image/asset_image.dart';
+import 'package:simple_catalog_app/scrollable/scrollable.dart';
 
 Future<void> main() async {
   testWidgets('Take snapshots', (tester) async {
@@ -13,6 +14,7 @@ Future<void> main() async {
         barStory(),
         fooWidgetStory(),
         assetImageStory(),
+        scrollableStory(),
       ],
     ).run(
       Snapshot(


### PR DESCRIPTION
## Overview
Support for calculating the snapshot size when Scrollables do not have a ScrollController.

## Context
When the primary property is set to false, the Scrollable's controller (ScrollController) property is null, as Scrollable creates a ScrollController in ScrollableState. Consequently, the playbook is unable to accurately calculate the snapshot size when the Scrollable content size exceeds the screen size.

## Copilot Summary
<details><summary>summary</summary>
<p>

This pull request primarily focuses on the implementation of a 'Scrollable' widget and related changes in the `simple_catalog_app` and `playbook_snapshot` packages. The changes include the creation of a new `scrollable` widget, the addition of `scrollableStory` to the snapshot test, and modifications in the `SnapshotSupport` class to handle the new `ScrollableState`.

New Widget Implementation:

* [`examples/simple_example/simple_catalog_app/lib/scrollable/scrollable.dart`](diffhunk://#diff-e2d8891546a9fc025f25a720ace1704af156e1f35a22c395f230f32ef3adda58R1-R44): A new `scrollable` widget has been implemented, which returns a `Row` widget containing two `ListView.builder` widgets. A new `scrollableStory` function has also been added to create a `Story` instance for the `scrollable` widget.

Test Updates:

* [`examples/simple_example/simple_catalog_app/test/snapshot_test.dart`](diffhunk://#diff-f96b7eed2ce43901f5d34a31f5ceb19db3f182679132fff087cbad221cd1f004R8): The `scrollableStory` has been added to the list of stories in the snapshot test. [[1]](diffhunk://#diff-f96b7eed2ce43901f5d34a31f5ceb19db3f182679132fff087cbad221cd1f004R8) [[2]](diffhunk://#diff-f96b7eed2ce43901f5d34a31f5ceb19db3f182679132fff087cbad221cd1f004R17)

Snapshot Support Changes:

* [`playbook_snapshot/lib/src/snapshot_support.dart`](diffhunk://#diff-fff5159dc341a53904cc6c7affbf7be06a242dd4ace517f9f896159253bd826aL54-R78): The `SnapshotSupport` class has been modified to find `ScrollableState` instances instead of `Scrollable` widgets. The `_extendScrollableSnapshotSize` method has also been updated to accept a `ScrollableState` instead of a `Scrollable`. [[1]](diffhunk://#diff-fff5159dc341a53904cc6c7affbf7be06a242dd4ace517f9f896159253bd826aL54-R78) [[2]](diffhunk://#diff-fff5159dc341a53904cc6c7affbf7be06a242dd4ace517f9f896159253bd826aL108-R130)

</p>
</details> 