### PR TITLE
feat: can use scenarioWidgetBuilder when snapshot

### DIFF
--- a/packages/playbook_snapshot/lib/src/snapshot.dart
+++ b/packages/playbook_snapshot/lib/src/snapshot.dart
@@ -46,6 +46,7 @@ class Snapshot implements TestTool {
     Playbook playbook,
     WidgetTester tester,
     PlaybookBuilder builder, {
+    ScenarioWidgetBuilder? scenarioWidgetBuilder,
     Future<void> Function(WidgetTester tester)? setUpEachTest,
   }) async {
     await tester.runAsync(() async {
@@ -80,6 +81,7 @@ class Snapshot implements TestTool {
               checkeredColor: checkeredColor,
               checkeredRectSize: checkeredRectSize,
               useMaterial: useMaterial,
+              builder: scenarioWidgetBuilder,
               scenario: scenario,
             ),
             device,

--- a/packages/playbook_snapshot/lib/src/test_tool.dart
+++ b/packages/playbook_snapshot/lib/src/test_tool.dart
@@ -10,6 +10,7 @@ abstract class TestTool {
     Playbook playbook,
     WidgetTester tester,
     PlaybookBuilder builder, {
+    ScenarioWidgetBuilder? scenarioWidgetBuilder,
     Future<void> Function(WidgetTester tester)? setUpEachTest,
   });
 }
@@ -19,12 +20,14 @@ extension PlaybookExt on Playbook {
     TestTool test,
     WidgetTester tester,
     PlaybookBuilder builder, {
+    ScenarioWidgetBuilder? scenarioWidgetBuilder,
     Future<void> Function(WidgetTester tester)? setUpEachTest,
   }) async {
     await test.run(
       this,
       tester,
       builder,
+      scenarioWidgetBuilder: scenarioWidgetBuilder,
       setUpEachTest: setUpEachTest,
     );
   }


### PR DESCRIPTION
## Overview
Snapshot now has a Builder for scenario

## Problem
PlaybookGallery has scenarioWidgetBuilder but Snapshot does not
If you want to give a specific change to a Snapshot, there is no way to do so.

## Solution
We have added the ability to specify scenarioWidgetBuilder in Snapshot.