### PR TITLE
chore: update dependencies and migrate to analyzer 8.x

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
         with:
-          flutter-version: 3.27.4
+          flutter-version: 3.32.4
           cache: true
 
       - name: Setup pub
         run: make setup/pub
 
       - name: Dart Analyzer
-        uses: invertase/github-action-dart-analyzer@v3
+        uses: invertase/github-action-dart-analyzer@e981b01a458d0bab71ee5da182e5b26687b7101b # v3.0.0
         with:
           fatal-infos: true
           working-directory: ./packages

--- a/examples/generator_app/pubspec.yaml
+++ b/examples/generator_app/pubspec.yaml
@@ -5,8 +5,8 @@ version: 1.0.0+1
 publish_to: "none"
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ^3.8.0
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/playbook/pubspec.yaml
+++ b/packages/playbook/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^9.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/playbook/pubspec.yaml
+++ b/packages/playbook/pubspec.yaml
@@ -6,8 +6,8 @@ documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ^3.8.0
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/playbook/pubspec.yaml
+++ b/packages/playbook/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^10.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/playbook_generator/pubspec.yaml
+++ b/packages/playbook_generator/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
   dart_style: ^3.0.1
 
 dev_dependencies:
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^10.0.0

--- a/packages/playbook_generator/pubspec.yaml
+++ b/packages/playbook_generator/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
   dart_style: ^3.0.1
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^9.0.0

--- a/packages/playbook_generator/pubspec.yaml
+++ b/packages/playbook_generator/pubspec.yaml
@@ -6,7 +6,7 @@ documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ^3.8.0
 
 dependencies:
   analyzer: ^7.4.5

--- a/packages/playbook_generator/pubspec.yaml
+++ b/packages/playbook_generator/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  analyzer: ^7.4.5
-  build: ^2.4.1
-  source_gen: ^2.0.0
+  analyzer: ^8.0.0
+  build: ^4.0.0
+  source_gen: ^4.0.0
   path: ^1.9.0
   glob: ^2.1.2
   code_builder: ^4.10.0

--- a/packages/playbook_snapshot/pubspec.yaml
+++ b/packages/playbook_snapshot/pubspec.yaml
@@ -6,8 +6,8 @@ documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ^3.8.0
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/playbook_snapshot/pubspec.yaml
+++ b/packages/playbook_snapshot/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
   yaml: ^3.1.2
 
 dev_dependencies:
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^10.0.0

--- a/packages/playbook_snapshot/pubspec.yaml
+++ b/packages/playbook_snapshot/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
   yaml: ^3.1.2
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^9.0.0

--- a/packages/playbook_ui/pubspec.yaml
+++ b/packages/playbook_ui/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^9.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/playbook_ui/pubspec.yaml
+++ b/packages/playbook_ui/pubspec.yaml
@@ -6,8 +6,8 @@ documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ^3.8.0
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/playbook_ui/pubspec.yaml
+++ b/packages/playbook_ui/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^10.0.0
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
 
 dev_dependencies:
   melos: ^6.0.0
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^9.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
 
 dev_dependencies:
   melos: ^6.0.0
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^10.0.0


### PR DESCRIPTION
## Overview
This PR updates SDK/Flutter version constraints, migrates to analyzer 8.x API, and updates CI workflows. The changes ensure compatibility with the latest tooling and resolve deprecation warnings.

## Changes
- **SDK and Flutter updates**:
  - Updated SDK constraint to `^3.8.0` across all packages
  - Updated Flutter constraint to `>=3.32.0` where applicable
  
- **Analyzer 8.x migration**:
  - Changed import from `element2.dart` to `element.dart` in playbook_generator
  - Updated element access patterns (`ClassFragment` → `ClassElement`, `TopLevelFunctionFragment` → `ExecutableElement`)
  - Replaced deprecated APIs (`librarySource.uri` → `uri`, `topLevelElements` → specific getters)
  
- **Dependency updates**:
  - `analyzer` from `^7.4.5` to `^8.0.0`
  - `build` from `^2.4.1` to `^4.0.0`
  - `source_gen` from `^2.0.0` to `^4.0.0`
  - `very_good_analysis` from `^7.0.0` to `^9.0.0`
  
- **CI workflow updates**:
  - Updated GitHub Actions to use SHA-pinned versions for security
  - Updated Flutter version to 3.32.4 in CI

## Test Instructions
1. Run `flutter pub get` in all packages
2. Run `dart analyze` to verify no errors
3. Run the generator app to ensure code generation works correctly
4. Verify CI workflow runs successfully

## References
- Related to analyzer 8.x migration requirements
- Addresses deprecation warnings in build tooling
- Improves CI security with SHA-pinned actions