### PR TITLE
chore: release version 1.2.0

### DIFF
--- a/packages/playbook/CHANGELOG.md
+++ b/packages/playbook/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+### Improvements
+
+- Updated SDK constraint to `^3.8.0`
+
 ## 1.1.0
 
 - **FEAT**: can set `ScenarioWidgetBuilder` to `ScenarioWidget`.

--- a/packages/playbook/pubspec.yaml
+++ b/packages/playbook/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playbook
 description: Playbook package.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/playbook-ui/playbook-flutter
 documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues

--- a/packages/playbook_generator/CHANGELOG.md
+++ b/packages/playbook_generator/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.2.0
+
+### Dependencies
+
+- **analyzer**: Updated from `^7.4.5` to `^8.0.0`
+- **build**: Updated from `^2.4.1` to `^4.0.0`
+- **source_gen**: Updated from `^2.0.0` to `^4.0.0`
+
+### Improvements
+
+- Migrated to analyzer 8.x API:
+  - Changed import from `element2.dart` to `element.dart`
+  - Updated element access patterns (`ClassFragment` → `ClassElement`, `TopLevelFunctionFragment` → `ExecutableElement`)
+  - Replaced deprecated APIs (`librarySource.uri` → `uri`, `topLevelElements` → specific getters like `topLevelFunctions` and `topLevelVariables`)
+- Updated SDK constraint to `^3.8.0`
+
 ## 1.1.0
 
 - upgrade analyzer to greater than 7.4.5.

--- a/packages/playbook_generator/pubspec.yaml
+++ b/packages/playbook_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playbook_generator
 description: Playbook Generator Package
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/playbook-ui/playbook-flutter
 documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues

--- a/packages/playbook_snapshot/CHANGELOG.md
+++ b/packages/playbook_snapshot/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+### Improvements
+
+- Updated SDK constraint to `^3.8.0`
+
 ## 1.0.2
 
 - **FIX**: can use scenarioWidgetBuilder when snapshot #93

--- a/packages/playbook_snapshot/pubspec.yaml
+++ b/packages/playbook_snapshot/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playbook_snapshot
 description: Playbook Snapshot package.
-version: 1.0.2
+version: 1.2.0
 repository: https://github.com/playbook-ui/playbook-flutter
 documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues

--- a/packages/playbook_ui/CHANGELOG.md
+++ b/packages/playbook_ui/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+### Improvements
+
+- Updated SDK constraint to `^3.8.0`
+
 ## 1.1.0
 
 - **FEAT**: can set `ScenarioWidgetBuilder` to `ScenarioWidget`.

--- a/packages/playbook_ui/pubspec.yaml
+++ b/packages/playbook_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playbook_ui
 description: Playbook UI package.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/playbook-ui/playbook-flutter
 documentation: https://github.com/playbook-ui/playbook-flutter
 issue_tracker: https://github.com/playbook-ui/playbook-flutter/issues


### PR DESCRIPTION
## Overview
Release version 1.2.0 for all packages with SDK constraint updates and analyzer 8.x migration.

## Changes
### All Packages (playbook, playbook_ui, playbook_snapshot)
- Updated SDK constraint to `^3.8.0`
- Bumped version from 1.1.0 to 1.2.0

### playbook_generator
- **Analyzer 8.x migration**:
  - Migrated from `element2.dart` to `element.dart`
  - Updated element access patterns (`ClassFragment` → `ClassElement`, `TopLevelFunctionFragment` → `ExecutableElement`)
  - Replaced deprecated APIs (`librarySource.uri` → `uri`, `topLevelElements` → specific getters)
- **Dependencies**:
  - analyzer: `^7.4.5` → `^8.0.0`
  - build: `^2.4.1` → `^4.0.0`
  - source_gen: `^2.0.0` → `^4.0.0`
- Bumped version from 1.1.0 to 1.2.0

## Test Instructions
1. Run `melos bootstrap` to update all package dependencies
2. Run `melos analyze` to verify no analysis issues
3. Run `melos test` to ensure all tests pass
4. Test code generation with playbook_generator

## References
- Based on #150 (dependencies and analyzer 8.x migration)
- Based on #151 (workspace configuration)