### PR TITLE
chore: update dependency analyzer to ^9.0.0

### DIFF
--- a/packages/playbook_generator/pubspec.yaml
+++ b/packages/playbook_generator/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^8.0.0
+  analyzer: ^9.0.0
   build: ^4.0.0
   source_gen: ^4.0.0
   path: ^1.9.0


### PR DESCRIPTION
## Overview
Update analyzer dependency from ^8.0.0 to ^9.0.0 in playbook_generator to keep up with the latest analyzer API.

## Changes
- **Dependency update**:
  - `analyzer` from `^8.0.0` to `^9.0.0`

## Test Instructions
1. Run `dart pub get` in the root directory
2. Run `flutter analyze` to verify no analysis errors
3. Run the generator to ensure code generation works correctly

## References
- Previous analyzer migration: #150
- analyzer changelog: https://pub.dev/packages/analyzer/changelog